### PR TITLE
Use `Cop::Base` API

### DIFF
--- a/lib/rubocop/cop/sequel/partial_constraint.rb
+++ b/lib/rubocop/cop/sequel/partial_constraint.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Sequel
       # PartialConstraint looks for missed usage of partial indexes.
-      class PartialConstraint < Cop
+      class PartialConstraint < Base
         MSG = "Constraint can't be partial, use where argument with index"
 
         def_node_matcher :add_partial_constraint?, <<-MATCHER
@@ -14,7 +14,7 @@ module RuboCop
         def on_send(node)
           return unless add_partial_constraint?(node)
 
-          add_offense(node, location: :selector, message: MSG)
+          add_offense(node.loc.selector, message: MSG)
         end
       end
     end

--- a/spec/rubocop/cop/sequel/partial_constraint_spec.rb
+++ b/spec/rubocop/cop/sequel/partial_constraint_spec.rb
@@ -6,10 +6,10 @@ describe RuboCop::Cop::Sequel::PartialConstraint do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when using where for constraint' do
-    inspect_source <<-RUBY
+    offenses = inspect_source(<<~RUBY)
       add_unique_constraint %i[col_1 col_2], where: "state != 'deleted'"
     RUBY
 
-    expect(cop.offenses.size).to eq(1)
+    expect(offenses.size).to eq(1)
   end
 end


### PR DESCRIPTION
Follow up to #18 and #11.

This PR uses `Cop::Base` API for `Sequel/PartialConstraint` cop.