### PR TITLE
Use `RESTRICT_ON_SEND`

### DIFF
--- a/lib/rubocop/cop/sequel/column_default.rb
+++ b/lib/rubocop/cop/sequel/column_default.rb
@@ -6,6 +6,7 @@ module RuboCop
       # ColumnDefault looks for column creation with a default value.
       class ColumnDefault < Base
         MSG = "Don't create new column with default values"
+        RESTRICT_ON_SEND = %i[add_column].freeze
 
         def_node_matcher :add_column_default?, <<-MATCHER
           (send _ :add_column ... (hash (pair (sym :default) _)))

--- a/lib/rubocop/cop/sequel/concurrent_index.rb
+++ b/lib/rubocop/cop/sequel/concurrent_index.rb
@@ -6,6 +6,7 @@ module RuboCop
       # ConcurrentIndex looks for non-concurrent index creation.
       class ConcurrentIndex < Base
         MSG = 'Prefer creating or dropping new index concurrently'
+        RESTRICT_ON_SEND = %i[add_index drop_index].freeze
 
         def_node_matcher :indexes?, <<-MATCHER
           (send _ {:add_index :drop_index} $...)

--- a/lib/rubocop/cop/sequel/json_column.rb
+++ b/lib/rubocop/cop/sequel/json_column.rb
@@ -6,6 +6,7 @@ module RuboCop
       # JSONColumn looks for non-JSONB columns.
       class JSONColumn < Base
         MSG = 'Use JSONB rather than JSON or hstore'
+        RESTRICT_ON_SEND = %i[add_column].freeze
 
         def_node_matcher :json_or_hstore?, <<-MATCHER
           (send _ :add_column ... (sym {:json :hstore}))

--- a/lib/rubocop/cop/sequel/partial_constraint.rb
+++ b/lib/rubocop/cop/sequel/partial_constraint.rb
@@ -6,6 +6,7 @@ module RuboCop
       # PartialConstraint looks for missed usage of partial indexes.
       class PartialConstraint < Base
         MSG = "Constraint can't be partial, use where argument with index"
+        RESTRICT_ON_SEND = %i[add_unique_constraint].freeze
 
         def_node_matcher :add_partial_constraint?, <<-MATCHER
           (send _ :add_unique_constraint ... (hash (pair (sym :where) _)))

--- a/lib/rubocop/cop/sequel/save_changes.rb
+++ b/lib/rubocop/cop/sequel/save_changes.rb
@@ -9,6 +9,7 @@ module RuboCop
 
         MSG = 'Use `Sequel::Model#save_changes` instead of '\
               '`Sequel::Model#save`.'
+        RESTRICT_ON_SEND = %i[save].freeze
 
         def_node_matcher :model_save?, <<-MATCHER
           (send _ :save)


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8365

This PR uses `RESTRICT_ON_SEND` to restrict callbacks `on_send` to specific method names only.