### PR TITLE
Suppress RuboCop offense

### DIFF
--- a/lib/rubocop/cop/sequel/save_changes.rb
+++ b/lib/rubocop/cop/sequel/save_changes.rb
@@ -7,8 +7,7 @@ module RuboCop
       class SaveChanges < Base
         extend AutoCorrector
 
-        MSG = 'Use `Sequel::Model#save_changes` instead of '\
-              '`Sequel::Model#save`.'
+        MSG = 'Use `Sequel::Model#save_changes` instead of `Sequel::Model#save`.'
         RESTRICT_ON_SEND = %i[save].freeze
 
         def_node_matcher :model_save?, <<-MATCHER


### PR DESCRIPTION
This PR suppresses the following RuboCop offense.

```console
% bundle exec rubocop
Inspecting 18 files
.......C..........

Offenses:

lib/rubocop/cop/sequel/save_changes.rb:10:61: C: [Correctable]
Layout/LineContinuationSpacing: Use one space in front of backslash.
        MSG = 'Use `Sequel::Model#save_changes` instead of '\
                                                            ^

18 files inspected, 1 offense detected, 1 offense autocorrectable
```