### PR TITLE
Added dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
How about using dependabot in this way?
When this works, a PullRequest is created as follows:
- https://github.com/ruby/bigdecimal/pull/242

Same as the PR here: https://github.com/rubocop/rubocop/pull/11215