### PR TITLE
Update RuboCop ConcurrentIndex message

### DIFF
--- a/lib/rubocop/cop/sequel/concurrent_index.rb
+++ b/lib/rubocop/cop/sequel/concurrent_index.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Sequel
       # ConcurrentIndex looks for non-concurrent index creation.
       class ConcurrentIndex < Base
-        MSG = 'Prefer creating or dropping new index concurrently'
+        MSG = 'Specify `concurrently` option when creating or dropping an index.'
         RESTRICT_ON_SEND = %i[add_index drop_index].freeze
 
         def_node_matcher :indexes?, <<-MATCHER


### PR DESCRIPTION
Relates to https://github.com/rubocop/rubocop-sequel/issues/38

Change the Sequel/ConcurrentIndex cop message to be more explicit about the `concurrent` option when adding/dropping an index