### PR TITLE
Clean Up spec files a bit

### DIFF
--- a/spec/rubocop/cop/sequel/concurrent_index_spec.rb
+++ b/spec/rubocop/cop/sequel/concurrent_index_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe RuboCop::Cop::Sequel::ConcurrentIndex do
+RSpec.describe RuboCop::Cop::Sequel::ConcurrentIndex do
   subject(:cop) { described_class.new }
 
   context 'without the concurrent option' do

--- a/spec/rubocop/cop/sequel/json_column_spec.rb
+++ b/spec/rubocop/cop/sequel/json_column_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe RuboCop::Cop::Sequel::JSONColumn do
+RSpec.describe RuboCop::Cop::Sequel::JSONColumn do
   subject(:cop) { described_class.new }
 
   context 'with add_column' do

--- a/spec/rubocop/cop/sequel/migration_name_spec.rb
+++ b/spec/rubocop/cop/sequel/migration_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe RuboCop::Cop::Sequel::MigrationName, :config do
+RSpec.describe RuboCop::Cop::Sequel::MigrationName, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:config) do

--- a/spec/rubocop/cop/sequel/partial_constraint_spec.rb
+++ b/spec/rubocop/cop/sequel/partial_constraint_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe RuboCop::Cop::Sequel::PartialConstraint do
+RSpec.describe RuboCop::Cop::Sequel::PartialConstraint do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when using where for constraint' do

--- a/spec/rubocop/cop/sequel/save_changes_spec.rb
+++ b/spec/rubocop/cop/sequel/save_changes_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe RuboCop::Cop::Sequel::SaveChanges do
+RSpec.describe RuboCop::Cop::Sequel::SaveChanges do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when using save' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,33 +5,12 @@ require 'rubocop/rspec/support'
 require 'rubocop-sequel'
 
 RSpec.configure do |config|
-  # rspec-expectations config goes here. You can use an alternate
-  # assertion/expectation library such as wrong or the stdlib/minitest
-  # assertions if you prefer.
-  config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4. It makes the `description`
-    # and `failure_message` of custom matchers include text for helper methods
-    # defined using `chain`, e.g.:
-    #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
-    # ...rather than:
-    #     # => "be bigger than 2"
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
+  config.include RuboCop::RSpec::ExpectOffense
+  config.disable_monkey_patching!
+  config.raise_errors_for_deprecations!
+  config.raise_on_warning = true
+  config.fail_if_no_examples = true
 
-  # rspec-mocks config goes here. You can use an alternate test double
-  # library (such as bogus or mocha) by changing the `mock_with` option here.
-  config.mock_with :rspec do |mocks|
-    # Prevents you from mocking or stubbing a method that does not exist on
-    # a real object. This is generally recommended, and will default to
-    # `true` in RSpec 4.
-    mocks.verify_partial_doubles = true
-  end
-
-  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
-  # have no way to turn it off -- the option exists only for backwards
-  # compatibility in RSpec 3). It causes shared context metadata to be
-  # inherited by the metadata hash of host groups and examples, rather than
-  # triggering implicit auto-inclusion in groups with matching metadata.
-  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.order = :random
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
## Changes

 - Removed unnecessary `require 'spec_helper'` lines from spec files as they are included globally.
 - Standardized test descriptions to use `RSpec.describe` for clarity and consistency.
 - Streamlined spec_helper.rb to include essential configurations.