### PR TITLE
Migration helper module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tags
 *.gem
 Gemfile.lock
+.DS_Store

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,12 @@ Sequel/ConcurrentIndex:
   VersionAdded: 0.0.1
   VersionChanged: 0.3.3
 
+Sequel/Helpers/Migration:
+  Description: Contains helper methods for detecting if a node is inside a `Sequel.migration` block
+  Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/Helpers/Migration
+  VersionAdded: 0.3.6
+  VersionChanged: 0.3.6
+
 Sequel/IrreversibleMigration:
   Description: >-
     Warns against using certain methods inside a migration file's `change` block that would cause the migration to become irreversible.
@@ -52,9 +58,3 @@ Sequel/SaveChanges:
   SafeAutoCorrect: false
   VersionAdded: '0.0.1'
   VersionChanged: '0.3.3'
-
-Sequel/Helpers/Migration:
-  Description: Contains helper methods for detecting if a node is inside a `Sequel.migration` block
-  Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/Helpers/Migration
-  VersionAdded: 0.3.6
-  VersionChanged: 0.3.6

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,12 +11,6 @@ Sequel/ConcurrentIndex:
   VersionAdded: 0.0.1
   VersionChanged: 0.3.3
 
-Sequel/Helpers/Migration:
-  Description: Contains helper methods for detecting if a node is inside a `Sequel.migration` block
-  Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/Helpers/Migration
-  VersionAdded: 0.3.6
-  VersionChanged: 0.3.6
-
 Sequel/IrreversibleMigration:
   Description: >-
     Warns against using certain methods inside a migration file's `change` block that would cause the migration to become irreversible.

--- a/config/default.yml
+++ b/config/default.yml
@@ -16,8 +16,8 @@ Sequel/IrreversibleMigration:
     Warns against using certain methods inside a migration file's `change` block that would cause the migration to become irreversible.
   Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/IrreversibleMigration
   Enabled: true
-  VersionAdded: 0.3.4
-  VersionChanged: 0.3.4
+  VersionAdded: 0.3.5
+  VersionChanged: 0.3.6
 
 Sequel/JSONColumn:
   Description: >-
@@ -52,3 +52,9 @@ Sequel/SaveChanges:
   SafeAutoCorrect: false
   VersionAdded: '0.0.1'
   VersionChanged: '0.3.3'
+
+Sequel/Helpers/Migration:
+  Description: Contains helper methods for detecting if a node is inside a `Sequel.migration` block
+  Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/Helpers/Migration
+  VersionAdded: 0.3.6
+  VersionChanged: 0.3.6

--- a/lib/rubocop-sequel.rb
+++ b/lib/rubocop-sequel.rb
@@ -7,6 +7,8 @@ require 'rubocop/sequel/inject'
 
 RuboCop::Sequel::Inject.defaults!
 
+require 'rubocop/cop/sequel/helpers/migration'
+
 require 'rubocop/cop/sequel/concurrent_index'
 require 'rubocop/cop/sequel/irreversible_migration'
 require 'rubocop/cop/sequel/json_column'

--- a/lib/rubocop-sequel.rb
+++ b/lib/rubocop-sequel.rb
@@ -7,7 +7,7 @@ require 'rubocop/sequel/inject'
 
 RuboCop::Sequel::Inject.defaults!
 
-require 'rubocop/cop/sequel/helpers/migration'
+require_relative 'rubocop/cop/sequel/helpers/migration'
 
 require 'rubocop/cop/sequel/concurrent_index'
 require 'rubocop/cop/sequel/irreversible_migration'

--- a/lib/rubocop/cop/sequel/concurrent_index.rb
+++ b/lib/rubocop/cop/sequel/concurrent_index.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Sequel
       # ConcurrentIndex looks for non-concurrent index creation.
       class ConcurrentIndex < Base
+        include Helpers::Migration
+
         MSG = 'Specify `concurrently` option when creating or dropping an index.'
         RESTRICT_ON_SEND = %i[add_index drop_index].freeze
 
@@ -13,6 +15,8 @@ module RuboCop
         MATCHER
 
         def on_send(node)
+          return unless within_sequel_migration?(node)
+
           indexes?(node) do |args|
             add_offense(node.loc.selector, message: MSG) if offensive?(args)
           end

--- a/lib/rubocop/cop/sequel/helpers/migration.rb
+++ b/lib/rubocop/cop/sequel/helpers/migration.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sequel
+      module Helpers
+        # Migration contains helper methods for detecting if a node is inside a `Sequel.migration` block
+        module Migration
+          extend NodePattern::Macros
+
+          def_node_matcher :sequel_migration_block?, <<~MATCHER
+            (block
+              (send
+                (const nil? :Sequel) :migration ...)
+              ...)
+          MATCHER
+
+          def within_sequel_migration?(node)
+            node.each_ancestor(:block).any? { |ancestor| sequel_migration_block?(ancestor) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sequel/irreversible_migration.rb
+++ b/lib/rubocop/cop/sequel/irreversible_migration.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Sequel
       # IrreversibleMigration looks for methods inside a `change` block that cannot be reversed.
       class IrreversibleMigration < Base
+        include RuboCop::Cop::Sequel::Helpers::Migration
+
         # https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html#label-A+Basic+Migration
         VALID_CHANGE_METHODS = %i[
           create_table
@@ -26,11 +28,12 @@ module RuboCop
           set_column_allow_null
         ].freeze
 
-        MSG = 'Avoid using `%<name>s` inside a `change` block. Use `up` & `down` blocks instead.'
-        PRIMARY_KEY_MSG = 'Avoid using `add_primary_key` with an array argument inside a `change` block.'
+        MSG = 'Avoid using "%<name>s" inside a "change" block. Use "up" & "down" blocks instead.'
+        PRIMARY_KEY_MSG = 'Avoid using "add_primary_key" with an array argument inside a "change" block.'
 
         def on_block(node)
           return unless node.method_name == :change
+          return unless within_sequel_migration?(node)
 
           body = node.body
           return unless body

--- a/lib/rubocop/cop/sequel/irreversible_migration.rb
+++ b/lib/rubocop/cop/sequel/irreversible_migration.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Sequel
       # IrreversibleMigration looks for methods inside a `change` block that cannot be reversed.
       class IrreversibleMigration < Base
-        include RuboCop::Cop::Sequel::Helpers::Migration
+        include Helpers::Migration
 
         # https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html#label-A+Basic+Migration
         VALID_CHANGE_METHODS = %i[

--- a/lib/rubocop/cop/sequel/partial_constraint.rb
+++ b/lib/rubocop/cop/sequel/partial_constraint.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Sequel
       # PartialConstraint looks for missed usage of partial indexes.
       class PartialConstraint < Base
+        include Helpers::Migration
+
         MSG = "Constraint can't be partial, use where argument with index"
         RESTRICT_ON_SEND = %i[add_unique_constraint].freeze
 
@@ -14,6 +16,7 @@ module RuboCop
 
         def on_send(node)
           return unless add_partial_constraint?(node)
+          return unless within_sequel_migration?(node)
 
           add_offense(node.loc.selector, message: MSG)
         end

--- a/lib/rubocop/sequel/version.rb
+++ b/lib/rubocop/sequel/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Sequel
     # This module holds the RuboCop Sequel version information.
     module Version
-      STRING = '0.3.5'
+      STRING = '0.3.6'
     end
   end
 end

--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.name          = 'rubocop-sequel'
   gem.require_paths = ['lib']
-  gem.version       = '0.3.5'
+  gem.version       = '0.3.6'
   gem.metadata['rubygems_mfa_required'] = 'true'
 
   gem.required_ruby_version = '>= 2.5'

--- a/spec/rubocop/cop/sequel/concurrent_index_spec.rb
+++ b/spec/rubocop/cop/sequel/concurrent_index_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Sequel::ConcurrentIndex do
+  include Spec::Helpers::Migration
+
   subject(:cop) { described_class.new }
 
   context 'without the concurrent option' do
     it 'registers an offense without options' do
-      offenses = inspect_source(<<~SOURCE)
+      offenses = inspect_source_within_migration(<<~SOURCE)
         add_index(:products, :name)
         drop_index(:products, :name)
       SOURCE
@@ -13,7 +15,7 @@ RSpec.describe RuboCop::Cop::Sequel::ConcurrentIndex do
     end
 
     it 'registers an offense with other options' do
-      offenses = inspect_source(<<~SOURCE)
+      offenses = inspect_source_within_migration(<<~SOURCE)
         add_index(:products, :name, unique: true)
         drop_index(:products, :name, unique: true)
       SOURCE
@@ -21,7 +23,7 @@ RSpec.describe RuboCop::Cop::Sequel::ConcurrentIndex do
     end
 
     it 'registers an offense with composite index' do
-      offenses = inspect_source(<<~SOURCE)
+      offenses = inspect_source_within_migration(<<~SOURCE)
         add_index(:products, [:name, :price], unique: true)
         drop_index(:products, [:name, :price])
       SOURCE
@@ -30,7 +32,7 @@ RSpec.describe RuboCop::Cop::Sequel::ConcurrentIndex do
   end
 
   it 'does not register an offense when using concurrent option' do
-    offenses = inspect_source(<<~SOURCE)
+    offenses = inspect_source_within_migration(<<~SOURCE)
       add_index(:products, :name, unique: true, concurrently: true)
       drop_index(:products, :name, concurrently: true)
     SOURCE

--- a/spec/rubocop/cop/sequel/helpers/migration.rb
+++ b/spec/rubocop/cop/sequel/helpers/migration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spec
+  module Helpers
+    module Migration
+      extend CopHelper
+
+      def inspect_source_within_migration(source, file = nil)
+        migration_wrapped_source = <<~SOURCE
+          Sequel.migration do
+            #{source}
+          end
+        SOURCE
+
+        inspect_source(migration_wrapped_source, file)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/sequel/irreversible_migration_spec.rb
+++ b/spec/rubocop/cop/sequel/irreversible_migration_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Sequel::IrreversibleMigration do
+  include Spec::Helpers::Migration
+
   subject(:cop) { described_class.new }
 
   context 'when inside a change block' do
     let(:invalid_source) do
       <<~SOURCE
-        Sequel.migration do
-          change do
-            alter_table(:stores) do
-              drop_column(:products, :name)
-              drop_index(:products, :price)
-            end
+        change do
+          alter_table(:stores) do
+            drop_column(:products, :name)
+            drop_index(:products, :price)
           end
         end
       SOURCE
@@ -19,43 +19,39 @@ RSpec.describe RuboCop::Cop::Sequel::IrreversibleMigration do
 
     let(:valid_source) do
       <<~SOURCE
-        Sequel.migration do
-          change do
-            alter_table(:stores) do
-              add_primary_key(:id)
-              add_column(:products, :name)
-              add_index(:products, :price)
-            end
+        change do
+          alter_table(:stores) do
+            add_primary_key(:id)
+            add_column(:products, :name)
+            add_index(:products, :price)
           end
         end
       SOURCE
     end
 
     it 'registers an offense when there is an invalid method' do
-      offenses = inspect_source(invalid_source)
+      offenses = inspect_source_within_migration(invalid_source)
       expect(offenses.size).to eq(2)
     end
 
     it 'does not register an offense with valid methods' do
-      offenses = inspect_source(valid_source)
+      offenses = inspect_source_within_migration(valid_source)
       expect(offenses).to be_empty
     end
 
     describe 'and an array is passed into `add_primary_key`' do
       let(:source) do
         <<~SOURCE
-          Sequel.migration do
-            change do
-              alter_table(:stores) do
-                add_primary_key([:owner_id, :name])
-              end
+          change do
+            alter_table(:stores) do
+              add_primary_key([:owner_id, :name])
             end
           end
         SOURCE
       end
 
       it 'registers an offense' do
-        offenses = inspect_source(source)
+        offenses = inspect_source_within_migration(source)
         expect(offenses.size).to eq(1)
       end
     end
@@ -64,20 +60,18 @@ RSpec.describe RuboCop::Cop::Sequel::IrreversibleMigration do
   context 'when inside an up block' do
     let(:source) do
       <<~SOURCE
-        Sequel.migration do
-          up do
-            alter_table(:stores) do
-              add_primary_key([:owner_id, :name])
-              add_column(:products, :name)
-              drop_index(:products, :price)
-            end
+        up do
+          alter_table(:stores) do
+            add_primary_key([:owner_id, :name])
+            add_column(:products, :name)
+            drop_index(:products, :price)
           end
         end
       SOURCE
     end
 
     it 'does not register an offense with any methods' do
-      offenses = inspect_source(source)
+      offenses = inspect_source_within_migration(source)
       expect(offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/sequel/json_column_spec.rb
+++ b/spec/rubocop/cop/sequel/json_column_spec.rb
@@ -1,48 +1,50 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Sequel::JSONColumn do
+  include Spec::Helpers::Migration
+
   subject(:cop) { described_class.new }
 
   context 'with add_column' do
     it 'registers an offense when using json type' do
-      offenses = inspect_source('add_column(:products, :type, :json)')
+      offenses = inspect_source_within_migration('add_column(:products, :type, :json)')
       expect(offenses.size).to eq(1)
     end
 
     it 'registers an offense when using hstore type' do
-      offenses = inspect_source('add_column(:products, :type, :hstore)')
+      offenses = inspect_source_within_migration('add_column(:products, :type, :hstore)')
       expect(offenses.size).to eq(1)
     end
 
     it 'does not register an offense when using jsonb' do
-      offenses = inspect_source('add_column(:products, :type, :jsonb)')
+      offenses = inspect_source_within_migration('add_column(:products, :type, :jsonb)')
       expect(offenses).to be_empty
     end
   end
 
   context 'with create_table' do
     it 'registers an offense when using json as a method' do
-      offenses = inspect_source('create_table(:products) { json :type, default: {} }')
+      offenses = inspect_source_within_migration('create_table(:products) { json :type, default: {} }')
       expect(offenses.size).to eq(1)
     end
 
     it 'registers an offense when using the column method with hstore' do
-      offenses = inspect_source('create_table(:products) { column :type, :hstore }')
+      offenses = inspect_source_within_migration('create_table(:products) { column :type, :hstore }')
       expect(offenses.size).to eq(1)
     end
 
     it 'does not register an offense when using jsonb as column type`' do
-      offenses = inspect_source('create_table(:products) { column :type, :jsonb }')
+      offenses = inspect_source_within_migration('create_table(:products) { column :type, :jsonb }')
       expect(offenses).to be_empty
     end
 
     it 'does not register an offense when using jsonb' do
-      offenses = inspect_source('create_table(:products) { jsonb :type }')
+      offenses = inspect_source_within_migration('create_table(:products) { jsonb :type }')
       expect(offenses).to be_empty
     end
 
     it 'does not register an offense when using a simple type' do
-      offenses = inspect_source('create_table(:products) { integer :type, default: 0 }')
+      offenses = inspect_source_within_migration('create_table(:products) { integer :type, default: 0 }')
       expect(offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/sequel/partial_constraint_spec.rb
+++ b/spec/rubocop/cop/sequel/partial_constraint_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Sequel::PartialConstraint do
+  include Spec::Helpers::Migration
+
   subject(:cop) { described_class.new }
 
   it 'registers an offense when using where for constraint' do
-    offenses = inspect_source(<<~RUBY)
+    offenses = inspect_source_within_migration(<<~RUBY)
       add_unique_constraint %i[col_1 col_2], where: "state != 'deleted'"
     RUBY
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 require 'rubocop-sequel'
 
+require_relative 'rubocop/cop/sequel/helpers/migration'
+
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense
   config.disable_monkey_patching!


### PR DESCRIPTION
Resolves this issue: https://github.com/rubocop/rubocop-sequel/issues/44
Bug was introduced in this PR: https://github.com/rubocop/rubocop-sequel/pull/43

### Primary Change
`IrreversibleMigration` will now check if a `change` block is inside a `Sequel.migration` block before checking for offenses

### New patterns

**lib**

- Created new directory: `lib/rubocop/cop/sequel/helpers/`
  - Within this directory, created `module Migration` (Can be included via `include Helpers::Migration`)
    - This helper module contains logic to check if a node is inside a migration, now available for use with other Cops
- Where relevant, existing cops have been refactored to use this new helper. Now they will check if a node is inside a `Sequel.migration` block before checking for offenses.

**spec**

- Created new directory: `spec/rubocop/cop/sequel/helpers`
  - Within this directory, created `module Migration` (Can be included via `include Spec::Helpers::Migration`)
    - New method: `#inspect_source_within_migration`
      - This is a wrapper for `#inspect_source`. Will wrap the `source` argument within a `Sequel.migration` block
- Refactored existing specs with this new method