### PR TITLE
`IrreversibleMigration`: Ignore methods that are part of another method call

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -17,7 +17,7 @@ Sequel/IrreversibleMigration:
   Reference: https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/IrreversibleMigration
   Enabled: true
   VersionAdded: 0.3.5
-  VersionChanged: 0.3.7
+  VersionChanged: 0.3.8
 
 Sequel/JSONColumn:
   Description: >-

--- a/lib/rubocop/sequel/version.rb
+++ b/lib/rubocop/sequel/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Sequel
     # This module holds the RuboCop Sequel version information.
     module Version
-      STRING = '0.3.7'
+      STRING = '0.3.8'
     end
   end
 end


### PR DESCRIPTION
### Reason for change

Resolves issue https://github.com/rubocop/rubocop-sequel/issues/48

Consider the following migration:

```ruby
Sequel.migration do
  change do
    alter_table(:stores) do
      add_column(:products, JSON, null: false, default: Sequel.pg_json({}))
      add_constraint(
        :only_one_user,
        (
          Sequel.cast(Sequel.~(user_id: nil), Integer) +
          Sequel.cast(Sequel.~(owner_id: nil), Integer)
        ) => 1,
      )
    end
  end
end
```

In the current state, the following offenses would be registered:

```
Sequel/IrreversibleMigration: Avoid using "pg_json" inside a "change" block. Use "up" & "down" blocks instead.
Sequel/IrreversibleMigration: Avoid using "+" inside a "change" block. Use "up" & "down" blocks instead.
Sequel/IrreversibleMigration: Avoid using "cast" inside a "change" block. Use "up" & "down" blocks instead.
Sequel/IrreversibleMigration: Avoid using "~" inside a "change" block. Use "up" & "down" blocks instead.
Sequel/IrreversibleMigration: Avoid using "cast" inside a "change" block. Use "up" & "down" blocks instead.
Sequel/IrreversibleMigration: Avoid using "~" inside a "change" block. Use "up" & "down" blocks instead.
```

Methods that are part of another method argument can be safely ignored, because an offense will still be registered if the parent method is invalid within a `change` block