### PR TITLE
Relax the upper restriction on rubocop

### DIFF
--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7'
 
   gem.add_dependency 'lint_roller', '~> 1.1'
-  gem.add_dependency 'rubocop', '>= 1.72.1', '< 1.74.0'
+  gem.add_dependency 'rubocop', '>= 1.72.1', '< 2'
 end


### PR DESCRIPTION
The RuboCop project releases often, it is not realistic to bump the version in the gemspec every time.

Addresses https://github.com/rubocop/rubocop-sequel/pull/52#issuecomment-2720564268