### PR TITLE
Optimize CI setup

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,3 +30,18 @@ jobs:
         run: bundle exec rubocop --parallel
       - name: RSpec
         run: bundle exec rspec
+
+  success:
+    name: Checks passing?
+    needs: main
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ needs.main.result == 'success' }}
+          then
+            echo "All checks passed"
+          else
+            echo "Some checks failed"
+            false
+          fi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   main:
     name: Ruby ${{ matrix.ruby }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,9 +24,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Install gems
-        run: bundle install
+          ruby-version: "${{ matrix.ruby }}"
+          bundler-cache: true
       - name: RuboCop
         run: bundle exec rubocop --parallel
       - name: RSpec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake', '~> 13.3.1'
 gem 'rspec', '~> 3.7'
 gem 'rubocop', '~> 1.76.0'
 gem 'rubocop-rspec', '~> 3.5.0'


### PR DESCRIPTION
### Trigger GitHub Actions on fewer events

When a pull request was opened, we would previously run all CI twice – once for the `push` event when the branch is pushed up, and once for the `pull_request` event when the PR is opened.

Now we will run CI only once when the PR is opened (or re-opened, or "synchronized" which I assume is when you push new changes). And we will run CI for the master branch when a PR is merged.

Some repositories configure CI to run _only_ on the `push` event, but that doesn't work when making changed on a forked repository.

###  Cache the gem installation on CI

###  Add job to validate success of matrix

We would like to configure branch protection rules, so that a PR cannot
be merged without CI passing. But configuring which checks need to pass
can be tedious when adding and removing Ruby versions. But by adding one 
job that validates the success of the matrix, it becomes simple.

### TODO

- [x] Add branch protection rule requiring that “Checks passing?” is successful.