### PR TITLE
Lazy load cops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec', '~> 3.7'
-gem 'rubocop', '~> 1.76.0'
+gem 'rubocop', '~> 1.89'
 gem 'rubocop-rspec', '~> 3.5.0'
 gem 'sequel', '~> 5.47'
 gem 'simplecov', '~> 0.16'

--- a/lib/rubocop-sequel.rb
+++ b/lib/rubocop-sequel.rb
@@ -5,11 +5,4 @@ require 'rubocop/sequel'
 require 'rubocop/sequel/version'
 require 'rubocop/sequel/plugin'
 
-require_relative 'rubocop/cop/sequel/helpers/migration'
-
-require 'rubocop/cop/sequel/concurrent_index'
-require 'rubocop/cop/sequel/irreversible_migration'
-require 'rubocop/cop/sequel/json_column'
-require 'rubocop/cop/sequel/migration_name'
-require 'rubocop/cop/sequel/save_changes'
-require 'rubocop/cop/sequel/partial_constraint'
+require 'rubocop/cop/sequel'

--- a/lib/rubocop/cop/sequel.rb
+++ b/lib/rubocop/cop/sequel.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'sequel/helpers/migration'
+
+module RuboCop
+  module Cop
+    # Cops for the `Sequel` department. The department's cops are
+    # registered for lazy loading and their files are loaded on demand.
+    module Sequel
+      extend LazyLoader
+
+      register_cop :ConcurrentIndex, "#{__dir__}/sequel/concurrent_index"
+      register_cop :IrreversibleMigration, "#{__dir__}/sequel/irreversible_migration"
+      register_cop :JSONColumn, "#{__dir__}/sequel/json_column"
+      register_cop :MigrationName, "#{__dir__}/sequel/migration_name"
+      register_cop :SaveChanges, "#{__dir__}/sequel/save_changes"
+      register_cop :PartialConstraint, "#{__dir__}/sequel/partial_constraint"
+    end
+  end
+end

--- a/rubocop-sequel.gemspec
+++ b/rubocop-sequel.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7'
 
   gem.add_dependency 'lint_roller', '~> 1.1'
-  gem.add_dependency 'rubocop', '>= 1.72.1', '< 2'
+  gem.add_dependency 'rubocop', '>= 1.89.0', '< 2'
 end

--- a/spec/lazy_loading_spec.rb
+++ b/spec/lazy_loading_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'cop lazy loading', type: :feature do
+  let(:cop_root) { File.expand_path('../lib/rubocop/cop', __dir__) }
+
+  def run_script(source)
+    Dir.mktmpdir do |dir|
+      script = File.join(dir, 'script.rb')
+      File.write(script, source)
+      output = `#{RbConfig.ruby} -I #{File.expand_path('../lib', __dir__)} #{script} 2>&1`
+      raise "script failed:\n#{output}" unless $CHILD_STATUS.success?
+
+      output
+    end
+  end
+
+  it 'registers every cop file in `lib/rubocop/cop/sequel` exactly once' do
+    files = Dir[File.join(cop_root, 'sequel', '*.rb')].sort
+    registered = RuboCop::Cop::Registry.global.cops_for_department(:Sequel).map do |cop|
+      Object.const_source_location(cop.name).first
+    end
+
+    expect(registered.sort).to eq(files)
+  end
+
+  it 'registers all cops without loading their files' do # rubocop:disable RSpec/ExampleLength
+    output = run_script(<<~RUBY)
+      require 'rubocop-sequel'
+
+      registry = RuboCop::Cop::Registry.global
+      loaded = $LOADED_FEATURES.grep(%r{/rubocop/cop/sequel/(?!helpers/)})
+
+      puts "registered=\#{registry.names.grep(%r{\\ASequel/}).size}"
+      puts "loaded_cop_files=\#{loaded.size}"
+    RUBY
+
+    expect(output).to include('registered=6', 'loaded_cop_files=0')
+  end
+
+  it 'does not register a cop twice when its file is required directly' do # rubocop:disable RSpec/ExampleLength
+    output = run_script(<<~RUBY)
+      require 'rubocop-sequel'
+
+      before = RuboCop::Cop::Registry.global.length
+      require 'rubocop/cop/sequel/json_column'
+      after = RuboCop::Cop::Registry.global.length
+
+      puts "stable=\#{before == after}"
+      puts "class=\#{RuboCop::Cop::Registry.global.find_by_cop_name('Sequel/JSONColumn')}"
+    RUBY
+
+    expect(output).to include('stable=true', 'class=RuboCop::Cop::Sequel::JSONColumn')
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/15436.

Replace the 6 cop requires in `lib/rubocop-sequel.rb` with a `Sequel` department module (`lib/rubocop/cop/sequel.rb`) that registers every cop with the global registry through `RuboCop::Cop::LazyLoader#register_cop` without loading the cop files. A cop's file is loaded only when the cop class is needed, which for an inspection run means only the enabled cops. This follows the same mechanism RuboCop core adopted in rubocop/rubocop#15436 and requires RuboCop 1.89.0+.

The `register_cop` directives keep the former require order, because the registration order defines the cop execution order. The `Helpers::Migration` module moves from the gem entry point to the top of the department module and stays eagerly required: four cops include it at class-body evaluation time without requiring it themselves.

A new `spec/lazy_loading_spec.rb` requires every cop file in `lib/rubocop/cop/sequel` to be registered exactly once and asserts the lazy behavior itself in subprocesses: no cop files loaded after `require 'rubocop-sequel'`, and no double registration when a cop file is required directly.