### PR TITLE
Use `any?` instead of `count.positive?`

### DIFF
--- a/lib/rubocop/cop/sequel/irreversible_migration.rb
+++ b/lib/rubocop/cop/sequel/irreversible_migration.rb
@@ -72,7 +72,7 @@ module RuboCop
         end
 
         def part_of_method_call?(node)
-          node.each_ancestor(:send).count.positive?
+          node.each_ancestor(:send).any?
         end
       end
     end


### PR DESCRIPTION
`Style/CollectionQuerying` in newer RuboCop versions reports this; `any?` also short-circuits instead of walking every ancestor.